### PR TITLE
Non-fatal warnings in dev + rewarn.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ out/
 .metals/
 .bsp/
 .hydra/
+metals.sbt
 
 # Vim
 *.swp
+
+# VSCode
+.vscode/

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ inThisBuild(
 addSbtPlugin("de.heikoseeberger"         % "sbt-header"   % "5.6.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.20")
 addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix" % "0.9.29")
+addSbtPlugin("com.timushev.sbt"          % "sbt-rewarn"   % "0.1.3")
 
 lazy val sbtLucuma = (project in file("."))
   .disablePlugins(LucumaPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ addSbtPlugin("com.geirsson"              % "sbt-ci-release" % "1.5.7")
 addSbtPlugin("de.heikoseeberger"         % "sbt-header"     % "5.6.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"   % "0.1.20")
 addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"   % "0.9.29")
-
+addSbtPlugin("com.timushev.sbt"          % "sbt-rewarn"     % "0.1.3")

--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -53,12 +53,13 @@ object LucumaPlugin extends AutoPlugin {
     )
 
     lazy val lucumaScalaJsSettings = Seq(
-      scalacOptions ~= (_.filterNot(Set("-Xcheckinit"))),
-      scalacOptions --= Seq("-Xfatal-warnings").filterNot(_ => insideCI.value)
+      scalacOptions ~= (_.filterNot(Set("-Xcheckinit")))
     )
 
     lazy val lucumaCommonSettings =
-      lucumaHeaderSettings
+      lucumaHeaderSettings ++ Seq(
+        scalacOptions --= Seq("-Xfatal-warnings").filterNot(_ => insideCI.value)
+      )
   }
 
   import autoImport._

--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -9,6 +9,7 @@ import sbt.Keys._
 import de.heikoseeberger.sbtheader.HeaderPlugin
 import _root_.io.github.davidgregory084.TpolecatPlugin
 import scalafix.sbt.ScalafixPlugin
+import com.timushev.sbt.rewarn.RewarnPlugin
 
 object LucumaPlugin extends AutoPlugin {
 
@@ -52,18 +53,18 @@ object LucumaPlugin extends AutoPlugin {
     )
 
     lazy val lucumaScalaJsSettings = Seq(
-      scalacOptions ~= (_.filterNot(Set("-Xcheckinit")))
+      scalacOptions ~= (_.filterNot(Set("-Xcheckinit"))),
+      scalacOptions --= Seq("-Xfatal-warnings").filterNot(_ => insideCI.value)
     )
 
     lazy val lucumaCommonSettings =
       lucumaHeaderSettings
-
   }
 
   import autoImport._
 
   override def requires: Plugins =
-    HeaderPlugin && TpolecatPlugin && ScalafixPlugin
+    HeaderPlugin && TpolecatPlugin && ScalafixPlugin && RewarnPlugin
 
   override def trigger: PluginTrigger =
     allRequirements


### PR DESCRIPTION
This PR makes warnings non-fatal in development environments while keeping them fatal in CI environments.

`rewarn` is used so that all unresolved warnings are always reported in every compilation  whereas the current compilation units produce the warnings or not).