### PR TITLE
add mima, version scheme

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,17 +3,17 @@ inThisBuild(
   (homepage := Some(url("https://github.com/gemini-hlsw/sbt-lucuma"))) +: lucumaPublishSettings
 )
 
-addSbtPlugin("de.heikoseeberger"         % "sbt-header"   % "5.6.0")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.20")
-addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix" % "0.9.32")
-addSbtPlugin("com.timushev.sbt"          % "sbt-rewarn"   % "0.1.3")
-
 lazy val sbtLucuma = (project in file("."))
   .disablePlugins(LucumaPlugin)
   .enablePlugins(SbtPlugin)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "sbt-lucuma",
+    addSbtPlugin("de.heikoseeberger"         % "sbt-header"             % "5.6.0"),
+    addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"           % "0.1.20"),
+    addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"           % "0.9.32"),
+    addSbtPlugin("com.timushev.sbt"          % "sbt-rewarn"             % "0.1.3"),
+    addSbtPlugin("io.chrisdavenport"         % "sbt-mima-version-check" % "0.1.2"),
   )
   .settings(lucumaHeaderSettings)
 

--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -7,9 +7,7 @@ import sbt._
 import sbt.Keys._
 
 import de.heikoseeberger.sbtheader.HeaderPlugin
-import _root_.io.github.davidgregory084.TpolecatPlugin
 import scalafix.sbt.ScalafixPlugin
-import com.timushev.sbt.rewarn.RewarnPlugin
 
 object LucumaPlugin extends AutoPlugin {
 
@@ -23,7 +21,8 @@ object LucumaPlugin extends AutoPlugin {
       resolvers += Resolver.sonatypeRepo("public"),
       semanticdbEnabled := true, // enable SemanticDB
       semanticdbVersion := scalafixSemanticdb.revision, // use Scalafix compatible version
-      scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0" // Include OrganizeImport scalafix
+      scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0", // Include OrganizeImport scalafix
+      versionScheme := Some("early-semver"),
     )
 
     lazy val lucumaHeaderSettings = Seq(
@@ -62,9 +61,6 @@ object LucumaPlugin extends AutoPlugin {
   }
 
   import autoImport._
-
-  override def requires: Plugins =
-    HeaderPlugin && TpolecatPlugin && ScalafixPlugin && RewarnPlugin
 
   override def trigger: PluginTrigger =
     allRequirements


### PR DESCRIPTION
This adds two things to the default build configuration, with the goal of making it safer for us to evolve our libraries independently and make it clear when downstream updates are and are not compatible.

- Artifacts we publish will now include metadata about the version scheme we're using, which will help SBT detect cases where evictions are not legal. For example, if you end up depending on lucuma-woozle versions 1.2.3 and 1.2.4, it will just use 1.2.4; but if you're depending o 1.2.3 and 4.5.6, sbt will fail the build because the version scheme says these versions are incompatible. The scheme I chose is early-semver (described [here](https://www.scala-sbt.org/1.x/docs/Publishing.html#Version+scheme)) which is what most Scala libraries use.
- Builds will now include [MiMa](https://github.com/lightbend/mima) which performs binary compatibility checks against previous artifacts, to ensure that the assigned version is legal. It also includes [mima-version-check](https://github.com/ChristopherDavenport/sbt-mima-version-check) which automatically computes the set of prior artifact versions, simply by walking back the current version number. **Any library with a version ≥ 0.1.0 should include `mimaReportBinaryIssues` in CI.**

