### PR TITLE
Fix publish settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,9 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
 
-      - name: Check that common scalafmt config is up to date
-        run: sbt '++${{ matrix.scala }}' 'project /' lucumaScalafmtCheck
-
       - name: Check headers and formatting
         if: matrix.java == 'temurin@8'
-        run: sbt '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
+        run: sbt '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck lucumaScalafmtCheck
 
       - name: Test
         run: sbt '++${{ matrix.scala }}' test

--- a/app/src/main/scala/lucuma/sbtplugin/LucumaAppPlugin.scala
+++ b/app/src/main/scala/lucuma/sbtplugin/LucumaAppPlugin.scala
@@ -46,24 +46,7 @@ object LucumaAppPlugin extends AutoPlugin {
   private val dateFormatter = DateTimeFormatter.BASIC_ISO_DATE
 
   private lazy val ciSettings = Seq(
-    githubWorkflowBuild := Seq(
-      WorkflowStep.Sbt(
-        List("headerCheckAll",
-             "scalafmtCheckAll",
-             "project /",
-             "scalafmtSbtCheck",
-             "lucumaScalafmtCheck"
-        ),
-        name = Some("Check headers and formatting"),
-        cond = Some(primaryJavaCond.value)
-      ),
-      WorkflowStep.Sbt(List("test"), name = Some("Test"))
-    )
+    githubWorkflowBuild += WorkflowStep.Sbt(List("test"), name = Some("Test"))
   )
-
-  private val primaryJavaCond = Def.setting {
-    val java = githubWorkflowJavaVersions.value.head
-    s"matrix.java == '${java.render}'"
-  }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,6 @@ lazy val lib = project
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-lucuma-lib",
-    addSbtPlugin("org.typelevel" % "sbt-typelevel" % sbtTypelevelVersion)
+    addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % sbtTypelevelVersion)
   )
   .dependsOn(core)

--- a/lib/src/main/scala/lucuma/sbtplugin/LucumaLibPlugin.scala
+++ b/lib/src/main/scala/lucuma/sbtplugin/LucumaLibPlugin.scala
@@ -5,24 +5,11 @@ package lucuma.sbtplugin
 
 import sbt._
 import org.typelevel.sbt._
-import org.typelevel.sbt.gha._
 
 object LucumaLibPlugin extends AutoPlugin {
 
-  override def requires = LucumaPlugin && LucumaScalafmtPlugin && TypelevelPlugin
+  override def requires = TypelevelCiReleasePlugin && LucumaPlugin && LucumaScalafmtPlugin
 
   override def trigger = allRequirements
-
-  import GenerativePlugin.autoImport._
-
-  override def buildSettings = Seq(
-    githubWorkflowBuild ~= { steps =>
-      val scalafmtCheck = WorkflowStep.Sbt(
-        List("project /", "lucumaScalafmtCheck"),
-        name = Some("Check that common scalafmt config is up to date")
-      )
-      scalafmtCheck +: steps
-    }
-  )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,9 @@ Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "cor
 Compile / unmanagedResourceDirectories += baseDirectory.value.getParentFile / "core" / "src" / "main" / "resources"
 Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "lib" / "src" / "main" / "scala"
 
-addSbtPlugin("org.typelevel"    % "sbt-typelevel" % "0.4.3")
-addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"  % "0.9.33")
-addSbtPlugin("com.timushev.sbt" % "sbt-rewarn"    % "0.1.3")
+addSbtPlugin("org.typelevel"     % "sbt-typelevel-settings"   % "0.4.3")
+addSbtPlugin("org.typelevel"     % "sbt-typelevel-ci-release" % "0.4.3")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"               % "5.6.0")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"             % "2.4.6")
+addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"             % "0.9.33")
+addSbtPlugin("com.timushev.sbt"  % "sbt-rewarn"               % "0.1.3")


### PR DESCRIPTION
So, this is a bit embarrassing :)

For some reason I couldn't track down the latest snapshot. Well, turns out it was published under `org.typelevel` 😅

After the plugin re-organizing in https://github.com/gemini-hlsw/sbt-lucuma/pull/145, the sbt-lucuma core plugin (which sets your publish settings) and the sbt-typelevel plugin (which sets Typelevel publish settings) now ended up at the "same level". Previously, sbt-lucuma depended on sbt-typelevel so the sbt-lucuma publish settings took priority. However, post-https://github.com/gemini-hlsw/sbt-lucuma/pull/145 sbt-lucuma-lib depends on both sbt-lucuma and sbt-typelevel (hence they are at the "same level"). The plugins were loaded in an arbitrary order and sbt-typelevel publish settings overrode the sbt-lucuma publish settings.

To mitigate this, I completely removed the dependency to sbt-typelevel and replaced it with sbt-typelevel-ci-release which does not prescribe any publish settings. I had to reshuffle some settings to replace some of the extra things sbt-typelevel did, but we end up in essentially the same place.

And just to be sure :)
```
sbt:sbt-lucuma> show organization
[info] core / organization
[info]  edu.gemini
[info] app / organization
[info]  edu.gemini
[info] lib / organization
[info]  edu.gemini
[info] organization
[info]  edu.gemini
```