### PR TITLE
Only enable coverage in build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,21 +79,6 @@ jobs:
       - name: Upload code coverage data
         run: 'bash <(curl -s https://codecov.io/bash)'
 
-      - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master')
-        run: mkdir -p target core/target app/target lib/target project/target
-
-      - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master')
-        run: tar cf targets.tar target core/target app/target lib/target project/target
-
-      - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master')
-        uses: actions/upload-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
-          path: targets.tar
-
   publish:
     name: Publish Artifacts
     needs: [build]
@@ -128,16 +113,6 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
-
-      - name: Download target directories (2.12.15)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15
-
-      - name: Inflate target directories (2.12.15)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
 
       - name: Import signing key
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''

--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -87,7 +87,9 @@ object LucumaPlugin extends AutoPlugin {
     )
 
     lazy val lucumaCoverageSettings = Seq(
-      coverageEnabled := githubIsWorkflowBuild.value, // enable in CI
+      coverageEnabled := { // enable in CI, but only for the build job
+        githubIsWorkflowBuild.value && Option(System.env("GITHUB_JOB")).contains("build"),
+      },
       githubWorkflowBuild += WorkflowStep.Sbt(
         List("coverageReport", "coverageAggregate"),
         name = Some("Aggregate coverage reports")

--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -88,7 +88,7 @@ object LucumaPlugin extends AutoPlugin {
 
     lazy val lucumaCoverageSettings = Seq(
       coverageEnabled := { // enable in CI, but only for the build job
-        githubIsWorkflowBuild.value && Option(System.env("GITHUB_JOB")).contains("build"),
+        githubIsWorkflowBuild.value && Option(System.getenv("GITHUB_JOB")).contains("build"),
       },
       githubWorkflowBuild += WorkflowStep.Sbt(
         List("coverageReport", "coverageAggregate"),

--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -87,9 +87,11 @@ object LucumaPlugin extends AutoPlugin {
     )
 
     lazy val lucumaCoverageSettings = Seq(
-      coverageEnabled := { // enable in CI, but only for the build job
+      coverageEnabled              := { // enable in CI, but only for the build job
         githubIsWorkflowBuild.value && Option(System.getenv("GITHUB_JOB")).contains("build"),
       },
+      // can't reuse artifacts b/c need to re-compile without coverage enabled
+      githubWorkflowArtifactUpload := false,
       githubWorkflowBuild += WorkflowStep.Sbt(
         List("coverageReport", "coverageAggregate"),
         name = Some("Aggregate coverage reports")


### PR DESCRIPTION
So I bungled this a bit 😅 Enabling coverage in CI not only enables it for tests, but also enables it for the publish step which messes up the published artifacts. These changes make sure that coverage is enabled only for the build/test job, and that the publish step recompiles the code without coverage enabled.