### PR TITLE
Move coverageReport step to postamble

### DIFF
--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -92,13 +92,15 @@ object LucumaPlugin extends AutoPlugin {
       },
       // can't reuse artifacts b/c need to re-compile without coverage enabled
       githubWorkflowArtifactUpload := false,
-      githubWorkflowBuild += WorkflowStep.Sbt(
-        List("coverageReport", "coverageAggregate"),
-        name = Some("Aggregate coverage reports")
-      ),
-      githubWorkflowBuildPostamble += WorkflowStep.Run(
-        List("bash <(curl -s https://codecov.io/bash)"),
-        name = Some("Upload code coverage data")
+      githubWorkflowBuildPostamble ++= Seq(
+        WorkflowStep.Sbt(
+          List("coverageReport", "coverageAggregate"),
+          name = Some("Aggregate coverage reports")
+        ),
+        WorkflowStep.Run(
+          List("bash <(curl -s https://codecov.io/bash)"),
+          name = Some("Upload code coverage data")
+        )
       )
     )
 


### PR DESCRIPTION
In practice this shouldn't make really make a difference. Currently we're losing these steps in the app plugin due to:
https://github.com/gemini-hlsw/sbt-lucuma/blob/16bd6e7f7d2a296f4b52a560aa5d9fc366673057/app/src/main/scala/lucuma/sbtplugin/LucumaAppPlugin.scala#L49-L50

The underlying problem is that manipulating these workflow steps programmatically is still much too brittle. I've been exploring some solutions to this problem in https://github.com/typelevel/sbt-typelevel/pull/102.