### PR TITLE
Manually add resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,9 @@ ThisBuild / tlBaseVersion       := "0.6"
 ThisBuild / scalaVersion        := "2.12.15"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
-ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
+ThisBuild / resolvers += "legacy-sonatype-snapshots".at(
+  "https://oss.sonatype.org/content/repositories/snapshots/"
+)
 val sbtTypelevelVersion = "0.4.3-32-5fff779-SNAPSHOT"
 
 lazy val core = project

--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -29,7 +29,9 @@ object LucumaPlugin extends AutoPlugin {
 
     lazy val lucumaGlobalSettings = Seq(
       scalaVersion                                   := "2.13.8",
-      resolvers += Resolver.sonatypeRepo("public"),
+      resolvers += "s01-sonatype-public".at(
+        "https://s01.oss.sonatype.org/content/repositories/public/"
+      ),
       semanticdbEnabled                              := true, // enable SemanticDB
       semanticdbVersion                              := scalafixSemanticdb.revision, // use Scalafix compatible version
       scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0" // Include OrganizeImport scalafix


### PR DESCRIPTION
Apparently the default names for the dependency resolvers were conflicting with the names for the publishing resolvers 😕 