### PR TITLE
Only warn about eviction errors in local development

### DIFF
--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -74,6 +74,12 @@ object LucumaPlugin extends AutoPlugin {
     lazy val lucumaCiSettings = Seq(
       githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17")),
       Def.derive(tlFatalWarnings := githubIsWorkflowBuild.value),
+      evictionErrorLevel         := {
+        if (githubIsWorkflowBuild.value)
+          Level.Error // fatal in CI
+        else
+          Level.Warn  // relaxed locally for snapshot testing, etc.
+      },
       githubWorkflowBuild        := {
         val scalafmtCheck = WorkflowStep.Sbt(
           List("headerCheckAll",


### PR DESCRIPTION
In CI they become fatal errors, like your compiler warnings. This makes it possible to test snapshots etc. locally.