### PR TITLE
Make eviction errors non-fatal on JS

### DIFF
--- a/core/src/main/scala/lucuma/sbtplugin/LucumaScalaJSPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaScalaJSPlugin.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.sbtplugin
+
+import org.scalajs.sbtplugin.ScalaJSPlugin
+import sbt._
+
+import Keys._
+
+object LucumaScalaJSPlugin extends AutoPlugin {
+
+  override def requires = ScalaJSPlugin
+
+  override def trigger = allRequirements
+
+  override def projectSettings = Seq(
+    evictionErrorLevel := Level.Warn
+  )
+
+}


### PR DESCRIPTION
Any binary-incompatibilities will be caught at linking-time anyway.