### PR TITLE
Set `tlJdkRelease := Some(17)`

### DIFF
--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -43,6 +43,10 @@ object LucumaPlugin extends AutoPlugin {
       scalaVersion       := crossScalaVersions.value.head
     )
 
+    lazy val lucumaScalacSettings = Seq(
+      tlJdkRelease := None
+    )
+
     lazy val lucumaDocSettings = Seq(
       Compile / doc / sources := Seq.empty
     )
@@ -216,6 +220,7 @@ object LucumaPlugin extends AutoPlugin {
 
   override val buildSettings =
     lucumaScalaVersionSettings ++
+      lucumaScalacSettings ++
       lucumaPublishSettings ++
       lucumaCiSettings ++
       lucumaCoverageBuildSettings ++

--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -44,7 +44,7 @@ object LucumaPlugin extends AutoPlugin {
     )
 
     lazy val lucumaScalacSettings = Seq(
-      tlJdkRelease := None
+      tlJdkRelease := Some(17)
     )
 
     lazy val lucumaDocSettings = Seq(


### PR DESCRIPTION
This allows to use APIs included in up to JDK 17, as well as emits optimized bytecode.