### PR TITLE
Try to fix coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' coverageReport coverageAggregate
 
       - name: Upload code coverage data
-        run: 'bash <(curl -s https://codecov.io/bash)'
+        uses: codecov/codecov-action@v3
 
   publish:
     name: Publish Artifacts


### PR DESCRIPTION
1. Add a new setting to enable/disable coverage. When `false` it will remove all coverage related steps from the workflow
```scala
ThisBuild / lucumaCoverage := false
```

2. Tweak the detection logic used to enable coverage for a sub project. If it's working correctly, it should be enabled for any JVM while running during the test step in CI.

3. Use the codecov github action instead of the bash script download, hopefully this should be more reliable.