### PR TITLE
Re-use existing header/scalafmt check step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@17'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-latest'
         run: sbt '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck lucumaScalafmtCheck lucumaScalafixCheck
 
       - name: Check scalafix lints

--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -114,19 +114,18 @@ object LucumaPlugin extends AutoPlugin {
           })
         }
       },
+      tlCiHeaderCheck            := true,
+      tlCiScalafmtCheck          := true,
       githubWorkflowBuild        := {
-        val scalafmtCheck = WorkflowStep.Sbt(
-          List("headerCheckAll",
-               "scalafmtCheckAll",
-               "project /",
-               "scalafmtSbtCheck",
-               "lucumaScalafmtCheck",
-               "lucumaScalafixCheck"
-          ),
-          name = Some("Check headers and formatting"),
-          cond = Some(primaryJavaCond.value)
-        )
-        scalafmtCheck +: githubWorkflowBuild.value
+        githubWorkflowBuild.value.map {
+          case step: WorkflowStep.Sbt if step.name.exists(_.contains("Check headers")) =>
+            step.copy(
+              commands = step.commands ++
+                List("lucumaScalafmtCheck").filter(_ => tlCiScalafmtCheck.value) ++
+                List("lucumaScalafixCheck").filter(_ => tlCiScalafixCheck.value)
+            )
+          case step                                                                    => step
+        }
       },
       tlCiScalafixCheck          := true,
       tlCiDocCheck               := false, // we are generating empty docs anyway


### PR DESCRIPTION
This way we properly respect the setting of `tlCiScalafmtCheck` etc.