### PR TITLE
Increase scalafmt limits even more

### DIFF
--- a/.scalafmt-common.conf
+++ b/.scalafmt-common.conf
@@ -8,7 +8,9 @@ version = "3.7.14"
 style = default
 
 runner.dialect = scala3
-runner.optimizer.maxVisitsPerToken = 20000 # Avoids SearchStateExploded exceptions
+# Avoids SearchStateExploded exceptions
+runner.maxStateVisits = 2000000
+runner.optimizer.maxVisitsPerToken = 200000
 
 maxColumn = 100
 project.git = true

--- a/core/src/main/resources/lucuma/sbtplugin/scalafmt-common.conf
+++ b/core/src/main/resources/lucuma/sbtplugin/scalafmt-common.conf
@@ -8,7 +8,9 @@ version = "3.7.14"
 style = default
 
 runner.dialect = scala3
-runner.optimizer.maxVisitsPerToken = 20000 # Avoids SearchStateExploded exceptions
+# Avoids SearchStateExploded exceptions
+runner.maxStateVisits = 2000000
+runner.optimizer.maxVisitsPerToken = 200000
 
 maxColumn = 100
 project.git = true


### PR DESCRIPTION
Turns out we kept hitting `SearchStateExploded` exceptions. This raises limits a lot. In some cases in observe, I would still get the exception with lower limits.