### PR TITLE
docker compose

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.11"
+ThisBuild / tlBaseVersion       := "0.12"
 ThisBuild / crossScalaVersions  := Seq("2.12.19")
 ThisBuild / tlCiReleaseBranches := Seq("master")
 

--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -193,12 +193,12 @@ object LucumaPlugin extends AutoPlugin {
     lazy val lucumaDockerComposeSettings = Seq(
       githubWorkflowBuildPreamble ++= {
         if (hasDockerComposeYml.value)
-          Seq(WorkflowStep.Run(List("docker-compose up -d"), name = Some("Docker compose up")))
+          Seq(WorkflowStep.Run(List("docker compose up -d"), name = Some("Docker compose up")))
         else Nil
       },
       githubWorkflowBuildPostamble ++= {
         if (hasDockerComposeYml.value)
-          Seq(WorkflowStep.Run(List("docker-compose down"), name = Some("Docker compose down")))
+          Seq(WorkflowStep.Run(List("docker compose down"), name = Some("Docker compose down")))
         else Nil
       }
     )


### PR DESCRIPTION
CI for `lucuma-odb` complains that it cannot find `docker-compose`.  Presumably it is now `docker compose` instead?  This is an attempt to fix it.  Since I have no idea how any of this works, somebody who knows better should review this.