### PR TITLE
Add `-Wunused:nowarn`

### DIFF
--- a/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaPlugin.scala
@@ -51,7 +51,15 @@ object LucumaPlugin extends AutoPlugin {
 
     lazy val lucumaScalacProjectSettings = Seq(
       // workaround https://github.com/fthomas/refined/pull/1317
-      scalacOptions += "-Wconf:msg=Given search preference for .*WitnessAs:s"
+      scalacOptions += "-Wconf:msg=Given search preference for .*WitnessAs:s",
+      // Move this the sbt-typelevel plugin?
+      // sbt-typelevel has better facilities for checking verions, but they are private
+      scalacOptions ++= {
+        if (scalaVersion.value.startsWith("3"))
+          Seq("-Wunused:nowarn")
+        else
+          Seq.empty
+      }
     )
 
     lazy val lucumaDocSettings = Seq(


### PR DESCRIPTION
With scala 3.7 there are more instances where we need to use `@nowarn`. This will let us know if we are unnecessarily suppressing warning.