### PR TITLE
Docker deploy plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ metals.sbt
 # VSCode
 .vscode/
 .direnv/
+sbt-launch.jar

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -40,6 +40,14 @@ pull_request_rules:
       add:
       - css
       remove: []
+- name: Label docker PRs
+  conditions:
+  - files~=^docker/
+  actions:
+    label:
+      add:
+      - docker
+      remove: []
 - name: Label jsdom PRs
   conditions:
   - files~=^jsdom/

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.12"
+ThisBuild / tlBaseVersion       := "0.13"
 ThisBuild / crossScalaVersions  := Seq("2.12.20")
 ThisBuild / tlCiReleaseBranches := Seq("main")
 

--- a/build.sbt
+++ b/build.sbt
@@ -84,3 +84,12 @@ lazy val jsdom = project
     ),
     tlVersionIntroduced := Map("2.12" -> "0.10.11")
   )
+
+lazy val docker = project
+  .in(file("docker"))
+  .enablePlugins(SbtPlugin)
+  .settings(
+    name := "sbt-lucuma-docker",
+    addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
+  )
+  .dependsOn(core)

--- a/docker/src/main/resources/lucuma/sbtplugin/heroku-docker-set-memory.sh
+++ b/docker/src/main/resources/lucuma/sbtplugin/heroku-docker-set-memory.sh
@@ -2,38 +2,38 @@
 if [[ "${JAVA_OPTS:-}" =~ -Xmx ]] || [[ "${JAVA_OPTS:-}" =~ -Xms ]] || [[ "${JAVA_OPTS:-}" =~ MaxRAMPercentage ]]; then
   echo "Custom heap settings detected in JAVA_OPTS, not overriding."
 else
-  DEFAULT_MB=512
-  MIN_HEAP_MB=256
-  DEFAULT_HEAP_PERCENT=80
-
-  # Allow override from environment variable
-  HEAP_PERCENT=${HEROKU_JAVA_HEAP_PERCENT:-$DEFAULT_HEAP_PERCENT}
-
   # Detect cgroup version and read memory limit
-  if [[ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]]; then
-    limit_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
-    echo "Detected cgroup v1: memory limit ${limit_bytes} bytes"
-  elif [[ -f /sys/fs/cgroup/memory.max ]]; then
+  if [[ -f /sys/fs/cgroup/memory.max ]]; then
     limit_bytes=$(cat /sys/fs/cgroup/memory.max)
     echo "Detected cgroup v2: memory limit ${limit_bytes} bytes"
+  elif [[ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]]; then
+    limit_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+    echo "Detected cgroup v1: memory limit ${limit_bytes} bytes"
   else
-    limit_bytes=$((DEFAULT_MB * 1024 * 1024))
-    echo "Cgroup memory limit not detected, using default ${DEFAULT_MB} MB"
+    limit_bytes=$((DEFAULT_MAX_HEAP_MB * 1024 * 1024))
+    echo "Cgroup memory limit not detected, using default ${DEFAULT_MAX_HEAP_MB} MB"
   fi
 
   if [[ "$limit_bytes" = "max" ]]; then
     echo "Dyno memory detected: MAX"
 
-    echo "Using -XX:MaxRAMPercentage=${HEAP_PERCENT}.0 instead of Xmx/Xms"
+    echo "Using -XX:MaxRAMPercentage=${HEAP_PERCENT}.0 instead of Xmx/Xms - IGNORING lucumaDockerHeapSubtract SETTING"
     addJava "-XX:MaxRAMPercentage=${HEAP_PERCENT}.0"
   else
     limit_mb=$((limit_bytes / 1024 / 1024))
 
     echo "Dyno memory detected: ${limit_mb} MB"
     heap_mb=$((limit_mb * HEAP_PERCENT / 100))
+    
+    # Apply heap subtraction if configured
+    if [[ $HEAP_SUBTRACT_MB -gt 0 ]]; then
+      echo "Subtracting ${HEAP_SUBTRACT_MB} MB from heap size"
+      heap_mb=$((heap_mb - HEAP_SUBTRACT_MB))
+    fi
 
     # Enforce minimum cap
     if (( heap_mb < MIN_HEAP_MB )); then
+      echo "Heap size below minimum, using ${MIN_HEAP_MB} MB instead"
       heap_mb=$MIN_HEAP_MB
     fi
 

--- a/docker/src/main/resources/lucuma/sbtplugin/heroku-docker-set-memory.sh
+++ b/docker/src/main/resources/lucuma/sbtplugin/heroku-docker-set-memory.sh
@@ -1,0 +1,45 @@
+# Only set heap if not already in JAVA_OPTS
+if [[ "${JAVA_OPTS:-}" =~ -Xmx ]] || [[ "${JAVA_OPTS:-}" =~ -Xms ]] || [[ "${JAVA_OPTS:-}" =~ MaxRAMPercentage ]]; then
+  echo "Custom heap settings detected in JAVA_OPTS, not overriding."
+else
+  DEFAULT_MB=512
+  MIN_HEAP_MB=256
+  DEFAULT_HEAP_PERCENT=80
+
+  # Allow override from environment variable
+  HEAP_PERCENT=${HEROKU_JAVA_HEAP_PERCENT:-$DEFAULT_HEAP_PERCENT}
+
+  # Detect cgroup version and read memory limit
+  if [[ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]]; then
+    limit_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+    echo "Detected cgroup v1: memory limit ${limit_bytes} bytes"
+  elif [[ -f /sys/fs/cgroup/memory.max ]]; then
+    limit_bytes=$(cat /sys/fs/cgroup/memory.max)
+    echo "Detected cgroup v2: memory limit ${limit_bytes} bytes"
+  else
+    limit_bytes=$((DEFAULT_MB * 1024 * 1024))
+    echo "Cgroup memory limit not detected, using default ${DEFAULT_MB} MB"
+  fi
+
+  if [[ "$limit_bytes" = "max" ]]; then
+    echo "Dyno memory detected: MAX"
+
+    echo "Using -XX:MaxRAMPercentage=${HEAP_PERCENT}.0 instead of Xmx/Xms"
+    addJava "-XX:MaxRAMPercentage=${HEAP_PERCENT}.0"
+  else
+    limit_mb=$((limit_bytes / 1024 / 1024))
+
+    echo "Dyno memory detected: ${limit_mb} MB"
+    heap_mb=$((limit_mb * HEAP_PERCENT / 100))
+
+    # Enforce minimum cap
+    if (( heap_mb < MIN_HEAP_MB )); then
+      heap_mb=$MIN_HEAP_MB
+    fi
+
+    echo "Using -Xms${heap_mb}m -Xmx${heap_mb}m"
+
+    addJava "-Xms${heap_mb}m"
+    addJava "-Xmx${heap_mb}m"
+  fi
+fi

--- a/docker/src/main/scala/lucuma/sbtplugin/LucumaDockerPlugin.scala
+++ b/docker/src/main/scala/lucuma/sbtplugin/LucumaDockerPlugin.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.sbtplugin
+
+import com.typesafe.sbt.packager.Keys.*
+import com.typesafe.sbt.packager.archetypes.JavaServerAppPackaging
+import com.typesafe.sbt.packager.docker.DockerPlugin
+import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.Docker
+import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.Universal
+import sbt.*
+import sbt.Keys.*
+
+import scala.io.Source
+
+object LucumaDockerPlugin extends AutoPlugin {
+
+  override def requires = DockerPlugin && JavaServerAppPackaging
+
+  override def trigger = allRequirements
+
+  override def projectSettings = Seq(
+    Docker / daemonUserUid          := Some("3624"),
+    Docker / daemonUser             := "software",
+    dockerBuildOptions ++= Seq("--platform", "linux/amd64"),
+    dockerUpdateLatest              := true,
+    dockerUsername                  := Some("noirlab"),
+    // No javadocs
+    Compile / packageDoc / mappings := Seq(),
+    // Don't create launchers for Windows
+    makeBatScripts                  := Seq.empty,
+    // Launch options
+    Universal / javaOptions ++= Seq(
+      // -J params will be added as jvm parameters
+      // Support remote JMX access
+      "-J-Dcom.sun.management.jmxremote",
+      "-J-Dcom.sun.management.jmxremote.authenticate=false",
+      "-J-Dcom.sun.management.jmxremote.port=2407",
+      "-J-Dcom.sun.management.jmxremote.ssl=false",
+      // Ensure the locale is correctly set
+      "-J-Duser.language=en",
+      "-J-Duser.country=US",
+      "-J-XX:+HeapDumpOnOutOfMemoryError",
+      // Make sure the application exits on OOM
+      "-J-XX:+ExitOnOutOfMemoryError",
+      "-J-XX:+CrashOnOutOfMemoryError",
+      "-J-XX:HeapDumpPath=/tmp",
+      "-J-Xrunjdwp:transport=dt_socket,address=8457,server=y,suspend=n"
+    ),
+    // From https://www.scala-sbt.org/sbt-native-packager/archetypes/java_app/customize.html#bash-and-bat-script-extra-defines
+    bashScriptExtraDefines ++= // extraLines
+      Source
+        .fromInputStream(getClass.getResourceAsStream("heroku-docker-set-memory.sh"))
+        .getLines
+        .toSeq
+  )
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,7 @@ val sbtTypelevelVersion       = "0.8.0" // Update in build.sbt as well
 addSbtPlugin("org.typelevel"     % "sbt-typelevel-settings"   % sbtTypelevelVersion)
 addSbtPlugin("org.typelevel"     % "sbt-typelevel-ci-release" % sbtTypelevelVersion)
 addSbtPlugin("org.typelevel"     % "sbt-typelevel-mergify"    % sbtTypelevelVersion)
+addSbtPlugin("com.github.sbt"    % "sbt-native-packager"      % "1.11.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"               % "5.10.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"             % "2.5.5")
 addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"             % "0.14.3")


### PR DESCRIPTION
Create a new `sbt-lucuma-docker` plugin that configures the native packager with our usual Docker settings, plus adding our manual mechanism for dynamic memory allocation that seems to be needed when deploying images to Heroku.