### PR TITLE
Bundle Heroku JVM agent in docker deploys

### DIFF
--- a/docker/src/main/resources/lucuma/sbtplugin/docker-set-memory.sh
+++ b/docker/src/main/resources/lucuma/sbtplugin/docker-set-memory.sh
@@ -34,7 +34,7 @@ else
     # 512 MB -> ~300 MB heap; 1024 MB -> ~675 MB heap, similar to Heroku's limits. System RAM is capped at 600 MB.
     SLOPE_PERCENT=26
     INTERCEPT=80
-    MAX_SYSTEM_RAM_MB=600
+    MAX_SYSTEM_RAM_MB=1024
 
     system_ram=$((limit_mb * SLOPE_PERCENT / 100 + INTERCEPT))
     # Cap system RAM at the maximum value

--- a/docker/src/main/scala/lucuma/sbtplugin/LucumaDockerPlugin.scala
+++ b/docker/src/main/scala/lucuma/sbtplugin/LucumaDockerPlugin.scala
@@ -12,10 +12,18 @@ import sbt.*
 import sbt.Keys.*
 
 import scala.io.Source
+import scala.sys.process.*
 
 object LucumaDockerPlugin extends AutoPlugin {
 
   override def requires = DockerPlugin && JavaServerAppPackaging
+
+  private val HerokuAgentVersion       = "4.0.4"
+  private val HerokuAgentFilename      = s"heroku-java-metrics-agent-${HerokuAgentVersion}.jar"
+  // We could use coursier/sbt to download this, but unles we put the time to delve into its API, this is straightforward and works.
+  private val HerokuAgentUrl           =
+    s"https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/${HerokuAgentVersion}/${HerokuAgentFilename}"
+  private val HerokuAgentTempTargetDir = "heroku-agent-tmp"
 
   object autoImport {
     lazy val lucumaDockerDefaultMaxHeap =
@@ -36,6 +44,8 @@ object LucumaDockerPlugin extends AutoPlugin {
       settingKey[Boolean](
         "If true, open debug ports in the JVM in the start script (default: false)"
       )
+    lazy val lucumaDockerUseHerokuAgent =
+      settingKey[Boolean]("If true, use the Heroku Java metrics agent (default: true)")
   }
 
   override def trigger = allRequirements
@@ -47,7 +57,8 @@ object LucumaDockerPlugin extends AutoPlugin {
     lucumaDockerMinHeap        := 256,
     lucumaDockerHeapPercentMax := 80,
     lucumaDockerHeapSubtract   := 0,
-    lucumaDockerOpenDebugPorts := false
+    lucumaDockerOpenDebugPorts := false,
+    lucumaDockerUseHerokuAgent := true
   )
 
   override def projectSettings = Seq(
@@ -57,6 +68,18 @@ object LucumaDockerPlugin extends AutoPlugin {
     dockerBuildOptions ++= Seq("--platform", "linux/amd64"),
     dockerUpdateLatest              := true,
     dockerUsername                  := Some("noirlab"),
+    Docker / mappings               := (Docker / mappings).value ++ {
+      if (lucumaDockerUseHerokuAgent.value) {
+        val tmpDir: File  = target.value / HerokuAgentTempTargetDir
+        tmpDir.mkdirs()
+        val tmpFile: File = tmpDir / HerokuAgentFilename
+        cleanFiles ++= Seq(tmpFile, tmpDir)
+        val status: Int   = url(HerokuAgentUrl) #> tmpFile !
+
+        if (status > 0) throw new RuntimeException(s"Failed to download $HerokuAgentUrl")
+        else Seq(tmpFile -> s"${(Docker / defaultLinuxInstallLocation).value}/$HerokuAgentFilename")
+      } else Seq.empty
+    },
     // No javadocs
     Compile / packageDoc / mappings := Seq(),
     // Omit sources
@@ -75,6 +98,11 @@ object LucumaDockerPlugin extends AutoPlugin {
       "-J-XX:+CrashOnOutOfMemoryError",
       "-J-XX:HeapDumpPath=/tmp"
     ),
+    Universal / javaOptions ++= {
+      if (lucumaDockerUseHerokuAgent.value)
+        Seq(s"-J-javaagent:${(Docker / defaultLinuxInstallLocation).value}/${HerokuAgentFilename}")
+      else Seq.empty
+    },
     // Optionally open debug ports
     Universal / javaOptions ++= {
       if (lucumaDockerOpenDebugPorts.value)


### PR DESCRIPTION
Enabled by default, the Heroku JVM agent reports JVM metrics to the Heroku app metrics page. We lost this functionality when moving to Docker and this is the official method of making it work again.

Also: increase max non-heap memory for large dynos.