### PR TITLE
Ignore flaky tests in Scala.js - also add README details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+Guidance for working in this repo. For end-user docs of each plugin, see `README.md`.
+
+## What this is
+
+`sbt-lucuma` is a set of **sbt AutoPlugins** providing shared build settings for Gemini
+lucuma projects (Scala version, CI/release, publishing, headers, scalafmt/scalafix, Scala.js,
+CSS bundling, Docker packaging). It is built on [sbt-typelevel](https://github.com/typelevel/sbt-typelevel).
+
+## Key facts (read before editing)
+
+- **Scala 2.12.21.** These are sbt 1.x plugins, which run on 2.12 — *not* Scala 3. Don't use
+  Scala 3 syntax here.
+- **Self-bootstrapping / dogfooding.** `project/plugins.sbt` adds the `core` and `lib` plugin
+  sources directly as `unmanagedSourceDirectories` of the meta-build, so this build uses its
+  own plugins to build itself (e.g. `lucumaScalafmtCheck`/`lucumaScalafixCheck` run in CI
+  here). Consequence: editing a `core`/`lib` plugin can change how *this* repo's own build
+  behaves, and a compile error there breaks the meta-build. Run a full `reload` after such
+  edits.
+- **Duplicated version pins.** `sbtTypelevelVersion` and `scalaJsVersion` are declared in
+  **both** `build.sbt` and `project/plugins.sbt` (with "update in the other as well" comments).
+  Bump both.
+
+## Module layout
+
+Each module is a separate sbt subproject and a separately published artifact. `app`, `lib`,
+and `docker` depend on `core`.
+
+| Dir | Artifact | Notable contents |
+| --- | --- | --- |
+| `core/` | `sbt-lucuma` | `LucumaPlugin` (umbrella), `LucumaScalaJSPlugin`, `LucumaScalafmtPlugin`, `LucumaScalafixPlugin`, `LucumaBundleMonPlugin`. Bundled resources: `scalafmt-common.conf`, `scalafix-common.conf`. |
+| `lib/` | `sbt-lucuma-lib` | `LucumaLibPlugin` (published libraries; adds MiMa). |
+| `app/` | `sbt-lucuma-app` | `LucumaAppPlugin` (applications; date+git version, no MiMa). |
+| `css/` | `sbt-lucuma-css` | `LucumaCssPlugin` (opt-in CSS bundling). Has scripted tests. |
+| `docker/` | `sbt-lucuma-docker` | `LucumaDockerPlugin`. `BuildInfoPlugin` exposes `HerokuAgentVersion`; bundled `docker-set-memory.sh`. |
+| `jsdom/` | `lucuma-jsdom` | `LucumaJSDOMNodeJSEnv` — a Scala.js `JSEnv`, **not** a plugin; added as a `libraryDependencies` in consumers' `project/`. |
+
+## Plugin conventions
+
+- Package `lucuma.sbtplugin`; objects extend `sbt.AutoPlugin`.
+- Public keys go in a nested `object autoImport { ... }`.
+- **Activation** is governed by `requires` + `trigger`:
+  - `trigger = allRequirements` → auto-enables wherever its `requires` are satisfied. A plugin
+    requiring `ScalaJSPlugin` therefore activates *only on Scala.js projects* (the JS side of a
+    crossProject) — this is how `LucumaScalaJSPlugin` keeps its settings JS-only.
+  - No `trigger` override (default `noTrigger`) → opt-in; consumers must
+    `.enablePlugins(...)` (e.g. `LucumaCssPlugin`).
+- Settings live in `globalSettings` / `buildSettings` / `projectSettings` as appropriate.
+- All `.scala` files carry the BSD-3-Clause AURA header (use `headerCreateAll` to apply).
+
+## Common commands
+
+```bash
+sbt compile                 # compile all modules (note: meta-build also compiles core/lib)
+sbt test                    # runs module tests; for css this runs the scripted tests
+sbt css/scripted            # run css scripted tests directly
+sbt <module>/publishLocal   # publish one artifact to ~/.ivy2/local for manual testing
+sbt headerCreateAll         # apply license headers
+sbt scalafmtAll scalafmtSbt # format
+```
+
+CI runs (see `.github/workflows/ci.yml`):
+
+```bash
+sbt headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck lucumaScalafmtCheck lucumaScalafixCheck
+sbt test
+sbt mimaReportBinaryIssues
+sbt tlCiRelease            # publish (release job)
+```
+
+## Testing a plugin change end-to-end
+
+`scripted` (in `css/src/sbt-test/...`) is the in-repo way to test plugin behavior. To verify a
+change against a real consuming build:
+
+1. `sbt <module>/publishLocal` and note the printed `-SNAPSHOT` version.
+2. In a throwaway build, `addSbtPlugin("edu.gemini" % "<artifact>" % "<snapshot>")` (or
+   `libraryDependencies += ... % lucuma-jsdom` in `project/`), then inspect the resulting
+   settings, e.g. `show fooJS/Test/testOptions` vs `show fooJVM/Test/testOptions`.
+
+## Releasing
+
+Released via sbt-typelevel CI (`tlCiRelease`) on the `main` branch / version tags. Versions are
+derived by `tlBaseVersion` (currently `0.14`) — do not hand-edit version numbers.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,182 @@
 # sbt-lucuma
 
-A simple plugin for shared build settings across Gemini lucuma projects.
+A collection of sbt plugins for shared build settings across Gemini lucuma projects.
 
+## Artifacts
+
+The plugins are split across several published artifacts. Most projects only need
+**one** of `sbt-lucuma-lib` (for published libraries) or `sbt-lucuma-app` (for
+applications) — both depend on the core `sbt-lucuma` artifact and pull in its plugins
+transitively. The CSS, Docker, and jsdom artifacts are added as needed.
+
+| Artifact | Add with | Provides |
+| --- | --- | --- |
+| `sbt-lucuma` | _(transitive — pulled by `-lib`/`-app`)_ | `LucumaPlugin`, `LucumaScalaJSPlugin`, `LucumaScalafmtPlugin`, `LucumaScalafixPlugin`, `LucumaBundleMonPlugin` |
+| `sbt-lucuma-lib` | `addSbtPlugin("edu.gemini" % "sbt-lucuma-lib" % V)` | `LucumaLibPlugin` (+ core) |
+| `sbt-lucuma-app` | `addSbtPlugin("edu.gemini" % "sbt-lucuma-app" % V)` | `LucumaAppPlugin` (+ core) |
+| `sbt-lucuma-css` | `addSbtPlugin("edu.gemini" % "sbt-lucuma-css" % V)` | `LucumaCssPlugin` |
+| `sbt-lucuma-docker` | `addSbtPlugin("edu.gemini" % "sbt-lucuma-docker" % V)` | `LucumaDockerPlugin` (+ core) |
+| `lucuma-jsdom` | `libraryDependencies += "edu.gemini" %% "lucuma-jsdom" % V` (in `project/`) | `LucumaJSDOMNodeJSEnv` |
+
+In the tables below, **Activation** is either:
+
+- **Automatic** — the plugin enables itself on every (qualifying) project once it is on
+  the build classpath (`trigger = allRequirements`); or
+- **Opt-in** — you must enable it explicitly with `.enablePlugins(...)` on a project.
+
+---
+
+## `sbt-lucuma` (core)
+
+### `LucumaPlugin`
+
+**Activation:** Automatic (on all projects, once `-lib` or `-app` is added).
+
+The umbrella plugin tying everything together. It requires the relevant
+[sbt-typelevel](https://github.com/typelevel/sbt-typelevel) plugins plus the lucuma
+scalafmt/scalafix/scoverage plugins, and configures sensible defaults across the build:
+
+- **Scala / JDK:** Scala `3.8.4`, `tlJdkRelease := 25`.
+- **Publishing:** `edu.gemini` organization, BSD-3-Clause license, developer list.
+- **CI:** fatal warnings in CI, `evictionErrorLevel` fatal in CI / relaxed locally,
+  header + scalafmt + scalafix checks wired into the workflow, Mergify config, doc/dependency
+  jobs disabled.
+- **Coverage:** scoverage enabled only in the CI `build` job (toggle with `lucumaCoverage`),
+  with coverage aggregation + Codecov upload appended to the workflow.
+- **Headers:** BSD-3-Clause C++-style line-comment header, applied automatically
+  (`AutomateHeaderPlugin`).
+- **Git versioning** and a `prePR` / `tlPrePrBotHook` command alias that regenerates the
+  workflow, headers, and scalafmt/scalafix configs.
+
+Selected `autoImport`:
+
+| Key | Description |
+| --- | --- |
+| `lucumaCoverage` | Globally enable/disable coverage (default `true`). |
+| `lucumaGlobalSettings`, `lucumaScalaVersionSettings`, `lucumaScalacSettings`, `lucumaScalacProjectSettings`, `lucumaPublishSettings`, `lucumaCiSettings`, `lucumaHeaderSettings`, `lucumaGitSettings`, `lucumaDocSettings`, `lucumaCoverageProjectSettings`, `lucumaCoverageBuildSettings`, `lucumaDockerComposeSettings`, `lucumaStewardSettings` | Reusable setting sequences, exposed so individual projects can opt in/out of pieces. |
+
+### `LucumaScalaJSPlugin`
+
+**Activation:** Automatic — requires `ScalaJSPlugin`, so it activates **only on Scala.js
+projects** (i.e. the JS side of a crossProject).
+
+- Sets `evictionErrorLevel := Level.Warn` for Scala.js projects.
+- **Flaky test handling on Scala.js.** MUnit reads `MUNIT_FLAKY_OK` via `System.getenv`
+  at test runtime, but `System.getenv` always returns `null` on Scala.js, so flaky tests
+  cannot be honored at runtime there. When `MUNIT_FLAKY_OK=true` is set, this plugin instead
+  excludes flaky-tagged MUnit tests on Scala.js at the build level
+  (`--exclude-tags=Flaky`, evaluated in the sbt JVM via `sys.env`). The JVM side is
+  untouched and keeps MUnit's normal runtime behavior.
+
+### `LucumaScalafmtPlugin`
+
+**Activation:** Automatic.
+
+Manages a shared scalafmt config (`.scalafmt-common.conf`) generated from a resource bundled
+in the plugin.
+
+| Task | Description |
+| --- | --- |
+| `lucumaScalafmtGenerate` | Write the common scalafmt config to the build root. |
+| `lucumaScalafmtCheck` | Fail if the on-disk config differs from the bundled one. |
+
+### `LucumaScalafixPlugin`
+
+**Activation:** Automatic.
+
+The scalafix counterpart to the above, managing `.scalafix-common.conf`.
+
+| Task | Description |
+| --- | --- |
+| `lucumaScalafixGenerate` | Write the common scalafix config to the build root. |
+| `lucumaScalafixCheck` | Fail if the on-disk config differs from the bundled one. |
+
+### `LucumaBundleMonPlugin`
+
+**Activation:** Automatic where `BundleMonPlugin` is present (requires `LucumaPlugin` &&
+`BundleMonPlugin`).
+
+Adds a "Monitor bundle size" CI step (runs `bundleMon` for the `rootJS` matrix project) and
+sets `bundleMonCompression := Brotli`.
+
+---
+
+## `sbt-lucuma-lib`
+
+### `LucumaLibPlugin`
+
+**Activation:** Automatic (requires `TypelevelCiReleasePlugin` && `LucumaPlugin` &&
+`LucumaScalafmtPlugin`).
+
+For **published libraries**. Pulls in CI release support and extends the `prePR` command
+alias with `mimaReportBinaryIssues` so binary-compatibility checks run as part of pre-PR
+verification.
+
+---
+
+## `sbt-lucuma-app`
+
+### `LucumaAppPlugin`
+
+**Activation:** Automatic (requires `LucumaPlugin` && `LucumaScalafmtPlugin`).
+
+For **applications** (as opposed to published libraries). Defines a date + git-hash version
+scheme (e.g. `20250101-abcdef12`, suffixed `-UNCOMMITTED` when the tree is dirty) and disables
+MiMa binary-issue checks (`tlCiMimaBinaryIssueCheck := false`).
+
+---
+
+## `sbt-lucuma-css`
+
+### `LucumaCssPlugin`
+
+**Activation:** Opt-in — `.enablePlugins(LucumaCssPlugin)` on a Scala.js project.
+
+Collects CSS assets (from both the classpath and dependency jars) into the target directory
+as part of the linking step, so stylesheets shipped inside lucuma libraries end up alongside
+the linked JS.
+
+| Key | Description |
+| --- | --- |
+| `lucumaCss` (task) | Copy CSS into `target/lucuma-css`; hooked into `fastLinkJS` / `fullLinkJS`. |
+| `lucumaCssExts` (setting) | File extensions treated as CSS (default `css`, `scss`, `saas`). |
+
+---
+
+## `sbt-lucuma-docker`
+
+### `LucumaDockerPlugin`
+
+**Activation:** Automatic where `DockerPlugin` && `JavaServerAppPackaging` are enabled.
+
+Opinionated Docker packaging (via sbt-native-packager) for lucuma server applications:
+
+- `eclipse-temurin:25-jre` base image, `noirlab` Docker username, non-root `software` user.
+- Heroku-compatible image manifest (`--provenance false --output type=docker`, `linux/amd64`).
+- OOM safety JVM options, locale settings, no Windows launchers, no javadocs/sources.
+- cgroups-aware heap sizing (via a bundled `docker-set-memory.sh`) and optional Heroku Java
+  metrics agent (downloaded at build time).
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `lucumaDockerDefaultMaxHeap` | `512` | Max heap (MB) when cgroups don't report a limit. |
+| `lucumaDockerMinHeap` | `256` | Minimum heap (MB). |
+| `lucumaDockerHeapPercentMax` | `80` | % of memory for heap when cgroups report `max`. |
+| `lucumaDockerHeapSubtract` | `0` | MB to subtract from the memory limit when sizing heap. |
+| `lucumaDockerOpenDebugPorts` | `false` | Open JMX / JDWP debug ports in the start script. |
+| `lucumaDockerUseHerokuAgent` | `true` | Bundle and attach the Heroku Java metrics agent. |
+
+---
+
+## `lucuma-jsdom`
+
+### `LucumaJSDOMNodeJSEnv`
+
+Not an sbt plugin — a custom Scala.js `JSEnv` (extending `JSDOMNodeJSEnv`) added as a build
+dependency. It injects browser globals (`document`, `window`, `navigator`, `Event`,
+`IS_REACT_ACT_ENVIRONMENT`, …) into the Node realm so React component tests can run under
+jsdom. Use it by setting:
+
+```scala
+jsEnv := new lucuma.LucumaJSDOMNodeJSEnv()
+```

--- a/core/src/main/scala/lucuma/sbtplugin/LucumaScalaJSPlugin.scala
+++ b/core/src/main/scala/lucuma/sbtplugin/LucumaScalaJSPlugin.scala
@@ -15,7 +15,19 @@ object LucumaScalaJSPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override def projectSettings = Seq(
-    evictionErrorLevel := Level.Warn
+    evictionErrorLevel := Level.Warn,
+    // MUnit reads MUNIT_FLAKY_OK via System.getenv at test runtime, which always returns
+    // empty on Scala.js -- so flaky tests cannot be honored at runtime there. When the env
+    // var is set, instead exclude flaky-tagged tests on Scala.js at the build level (this is
+    // evaluated here in the sbt JVM via sys.env and passed to MUnit as a test argument). This
+    // plugin requires ScalaJSPlugin, so it only activates on the JS project of a crossProject;
+    // the JVM side keeps MUnit's normal runtime MUNIT_FLAKY_OK behavior.
+    Test / testOptions ++= {
+      if (sys.env.get("MUNIT_FLAKY_OK").contains("true"))
+        Seq(Tests.Argument(new TestFramework("munit.Framework"), "--exclude-tags=Flaky"))
+      else
+        Nil
+    }
   )
 
 }

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735644329,
-        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735915915,
-        "narHash": "sha256-Q4HuFAvoKAIiTRZTUxJ0ZXeTC7lLfC9/dggGHNXNlCw=",
+        "lastModified": 1781359544,
+        "narHash": "sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a27871180d30ebee8aa6b11bf7fef8a52f024733",
+        "rev": "9f11f828c213641c2369a9f1fa31fe31557e3156",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1736435092,
-        "narHash": "sha256-tKijRvo6sD5z+VcY+7feu0y4BM8KAYdtJ1bx/W0ISi4=",
+        "lastModified": 1781531207,
+        "narHash": "sha256-rZKx58CHL6iuBBids64n8OTk1S6/JdrnN4gJYuhn1cc=",
         "owner": "typelevel",
         "repo": "typelevel-nix",
-        "rev": "c5d688bb44948714c7691adf348b7b8bffc516e6",
+        "rev": "c6a694aae59a084551cc04fd948a9543af611789",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
           imports = [ typelevel-nix.typelevelShell ];
           typelevelShell = {
             nodejs.enable = true;
-            jdk.package = pkgs.jdk17;
+            jdk.package = pkgs.jdk25;
           };
         };
       }


### PR DESCRIPTION
I'm tired of already-long release trains failing because of flaky tests.

We have set the `MUNIT_FLAKY_OK` env variable everywhere but it turns out this is ignored when running in Scala.js. This PR adds logic to the automatically-applied `LucumaScalaJSPlugin` so that when the env variable set and we are running tests in Scala.js, flaky tests are excluded. I think this is the least-friction path to honor flaky tests since it doesn't involve any changes downstream, nor special things to have in mind when implementing new tests.

Also, I asked Claude to write documentation of all the plugins implemented here.

Also, JDK update.